### PR TITLE
CloudCasa - Release 1.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,6 @@
       "repo": "catalogicsoftware/cloudcasa-rancher-extension",
       "branch": "gh-pages",
       "versions": [
-        "0.4.0",
-        "0.4.1",
-        "1.0.0",
         "1.0.1"
       ]
     },


### PR DESCRIPTION
Due to assets being moved since 0.4.0, the build was failing to find the icon. We can just release 1.0.1 as there is no need to allow users to go backwards to versions that have since had breaking changes.