### PR TITLE
Added new release for CloudCasa (1.0.2)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
       "repo": "catalogicsoftware/cloudcasa-rancher-extension",
       "branch": "gh-pages",
       "versions": [
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "kamaji": {


### PR DESCRIPTION
Changes include: 

1. Rename pause/resume backup to pause/resume backup schedule
2. Hide pausing/resuming if backup schedule does not exist
3. Readme cleanup

