### PR TITLE
add Codezero extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,13 @@
         "1.0.2"
       ]
     },
+    "codezero": {
+      "repo": "c6o/codezero-rancher-extension",
+      "branch": "gh-pages",
+      "versions": [
+        "0.1.0"
+      ]
+    },
     "kamaji": {
       "repo": "clastix/rancher-extension-clastix",
       "branch": "gh-pages",

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
       "repo": "c6o/codezero-rancher-extension",
       "branch": "gh-pages",
       "versions": [
-        "0.1.0"
+        "0.1.0",
+        "0.1.1"
       ]
     },
     "kamaji": {

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
         "1.0.2"
       ]
     },
-    "codezero": {
+    "codezero-rancher-extension": {
       "repo": "c6o/codezero-rancher-extension",
       "branch": "gh-pages",
       "versions": [


### PR DESCRIPTION
This extension allows one-click installation of Codezero into Rancher clusters.

For more detailed usage, see
https://github.com/c6o/codezero-rancher-extension/blob/main/README.md